### PR TITLE
Client: List call should return total items as well

### DIFF
--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -24,7 +24,7 @@ import (
 )
 
 type GenericInterface[T any] interface {
-	List(context.Context, query.Interface) ([]*T, error)
+	List(context.Context, query.Interface) ([]*T, int, error)
 	Create(context.Context, *T) (*T, error)
 	Get(context.Context, string) (*T, error)
 	Delete(context.Context, string) error


### PR DESCRIPTION
To fully support server-side paging, it's vital to have
total count of items. Return it along current page everytime
so client can make decisions based on it (such as setup
paging controls etc.)

Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
